### PR TITLE
Add support for allocate and best effort cycle per priority group

### DIFF
--- a/pkg/config/types.go
+++ b/pkg/config/types.go
@@ -123,11 +123,12 @@ type OptimizerData struct {
 
 // Specifications for optimizer data
 type OptimizerSpec struct {
-	Unlimited        bool   `json:"unlimited"`        // unlimited number of accelerator types (for capacity planning and/or cloud)
-	Heterogeneous    bool   `json:"heterogeneous"`    // heterogeneous accelerators assigned to same inference server
-	MILPSolver       bool   `json:"milpSolver"`       // use MILP solver to optimize
-	UseCplex         bool   `json:"useCplex"`         // use CPLEX solver for MILP problem
-	SaturationPolicy string `json:"saturationPolicy"` // allocation policy under saturated condition
+	Unlimited         bool   `json:"unlimited"`         // unlimited number of accelerator types (for capacity planning and/or cloud)
+	Heterogeneous     bool   `json:"heterogeneous"`     // heterogeneous accelerators assigned to same inference server
+	MILPSolver        bool   `json:"milpSolver"`        // use MILP solver to optimize
+	UseCplex          bool   `json:"useCplex"`          // use CPLEX solver for MILP problem
+	DelayedBestEffort bool   `json:"delayedBestEffort"` // delay best effort allocation after attempting allocation to all priority groups
+	SaturationPolicy  string `json:"saturationPolicy"`  // allocation policy under saturated condition
 }
 
 type AllocationSolution struct {

--- a/rest-server/README.md
+++ b/rest-server/README.md
@@ -216,10 +216,11 @@ The following data is needed by the Optimizer (Declarations described [types](..
     ```json
     {
         "optimizer": {
-            "unlimited": true,
+            "unlimited": false,
             "heterogeneous": false,
             "milpSolver" : false,
             "useCplex" : false,
+            "delayedBestEffort": false,
             "saturationPolicy" : "None"
         }
     }
@@ -231,6 +232,7 @@ The following data is needed by the Optimizer (Declarations described [types](..
     - `heterogeneous`: Whether servers accomodate heterogeneous accelerators for their replicas, e.g. five replicas of a server, two of which run on A100 and the other three run on G2.
     - `milpSolver`: Option to use an MILP (mixed Integer Linear Programming) problem solver, or rely on a (default) greedy algorithm. Currently, the provided solvers are: lpSolve and CPLEX.
     - `useCplex`: If using an MILP solver, use CPLEX.
+    - `delayedBestEffort`: Delay best effort allocation after attempting allocation to all priority groups.
     - `saturationPolicy`: Set an allocation policy under saturated condition.
 
       - ***None***: no additional allocation beyond satisfying SLOs


### PR DESCRIPTION
**BEFORE**

The greedy algorithm works in two phases, in series:

- Satisfy SLOs (_Allocate_): Go through servers in priority order and allocate GPUs to servers so as to satisfy their SLOs. If cannot satisfy SLOs for a server (not enough GPUs), that server is skipped and processed in phase 2. Subsequent servers in the ordered list continue to be processed.
- Apply saturation policy (_Best Effort_): For the servers that got no allocation in phase 1, order and process them according to the saturation policy. None, some, or all servers will get GPUs, but not enough to satisfy their SLOs.

Accordingly, it may very well happen, that a low priority server get allocated GPUs and have its SLOs satisfied, whereas a high priority server may get no allocation or an allocation that does not meet its SLOs.

**AFTER**

Added option `DelayedBestEffort`, with value `true` resulting in old behavior, and value `false` in new (default) behavior.

```
// Specifications for optimizer data
type OptimizerSpec struct {
	Unlimited         bool   `json:"unlimited"`         // unlimited number of accelerator types (for capacity planning and/or cloud)
	DelayedBestEffort bool   `json:"delayedBestEffort"` // delay best effort allocation after attempting allocation to all priority groups
	SaturationPolicy  string `json:"saturationPolicy"`  // allocation policy under saturated condition
}
```

New procedure:
- group servers with same priority, and
- for each group, in order, execute the two phases, before moving on to the next group.

